### PR TITLE
SWDEV-477849: Remove dependency of libatomic from roctracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To use the rocTX API you need the API header and to link your application with `
   1. For Ubuntu 18.04 and Ubuntu 20.04 the following adds the needed packages:
 
    ````shell
-   apt install python3 python3-pip gcc g++ libatomic1 make \
+   apt install python3 python3-pip gcc g++ make \
     cmake doxygen graphviz texlive-full
    ````
 
@@ -107,7 +107,7 @@ To use the rocTX API you need the API header and to link your application with `
 
    ````shell
    yum install -y python3 python3-pip gcc gcc-g++ make \
-    cmake libatomic doxygen graphviz texlive \
+    cmake doxygen graphviz texlive \
     texlive-xtab texlive-multirow texlive-sectsty \
     texlive-tocloft texlive-tabu texlive-adjustbox
    ````
@@ -116,7 +116,7 @@ To use the rocTX API you need the API header and to link your application with `
 
    ````shell
    zypper in python3 python3-pip gcc gcc-g++ make \
-    cmake libatomic doxygen graphviz \
+    cmake doxygen graphviz \
     texlive-scheme-medium texlive-hanging texlive-stackengine \
     texlive-tocloft texlive-etoc texlive-tabu
    ````


### PR DESCRIPTION
- **Work Item**: Internal
- **What were the Changes?** libatomic dependency has already been removed, so this PR is only removing references to the library from the README
- **Why were the Changes Made?** Internal ticket requesting removal of libatomic dependency. Upon investigation, ROCTracer does not use libatomic, so this PR only removes references to library in the README.
- **How was the outcome achieved?** I used _dpkg -L libatomic1_ to locate the files belonging to the libatomic package. I removed the shared library objects (libatomic.so.1.2.0 and libatomic.so.1) and then successfully ran the build script and the unit tests with no errors. I also searched the repository for any reference to libatomic or libatomic1 and could not find anything referencing this library nor the shared library objects above. 
- **No additional Documentation**