### PR TITLE
Add CMake option to control -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,11 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_compile_options(-Wall -Werror)
+add_compile_options(-Wall)
+option(ROCTRACER_WERROR "Treat warnings as errors" ON)
+if(ROCTRACER_WERROR)
+  add_compile_options(-Werror)
+endif()
 # To set addition RUNPATH in libraries
 # installed in /opt/rocm-ver/lib/roctracer
 set(ROCM_APPEND_PRIVLIB_RPATH "$ORIGIN/..")


### PR DESCRIPTION
This change allows -Werror to be disabled, which may be necessary when building in an environment which differs from that of the original developers (e.g., with a different compiler version).